### PR TITLE
Use freeifaddrs

### DIFF
--- a/minimdnsd.c
+++ b/minimdnsd.c
@@ -239,6 +239,7 @@ int HandleRequestingInterfaces()
 		{
 			struct sockaddr * addr = ifa->ifa_addr;
 			CheckAndAddMulticast( addr );
+			freeifaddrs( ifaddr );
 		}
 	}
 	return 0;


### PR DESCRIPTION
> The data returned by getifaddrs() is dynamically allocated and should be freed using freeifaddrs() when no longer needed.

https://linux.die.net/man/3/freeifaddrs